### PR TITLE
Add `validate` command

### DIFF
--- a/.changeset/chilly-clowns-start.md
+++ b/.changeset/chilly-clowns-start.md
@@ -1,0 +1,5 @@
+---
+'@codeowners-flow/cli': minor
+---
+
+Enhance string formatting while generating CODEOWNERS

--- a/.changeset/light-keys-crash.md
+++ b/.changeset/light-keys-crash.md
@@ -1,0 +1,5 @@
+---
+'@codeowners-flow/cli': minor
+---
+
+Add new "validate" command

--- a/.changeset/light-keys-crash.md
+++ b/.changeset/light-keys-crash.md
@@ -2,4 +2,6 @@
 '@codeowners-flow/cli': minor
 ---
 
-Add new "validate" command
+Add new "validate" command.
+
+With `codeowners-flow validate`, you can validate your CODEOWNERS file against a set of rules and ensure that it meets the required format and structure.

--- a/.changeset/purple-candies-matter.md
+++ b/.changeset/purple-candies-matter.md
@@ -1,0 +1,5 @@
+---
+'@codeowners-flow/cli': minor
+---
+
+Fix init boilerplate to import "defineConfig" from CLI

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,6 @@
 # Instead, modify the `codeowners.config.mjs` file located at the root of your project.
 
 # -------------------- START -------------------- #
-# Everything else will be fallback to @company/core-team to approve
 ## Matching patterns...
-* @company/core-team @company/infra-team
-# -------------------- END -------------------- #
-
-# -------------------- START -------------------- #
-## Matching patterns...
-apps/website-frontend @company/website-team @company/core-team @company/infra-team
-## Except...
-apps/website-frontend/github
+* @company-team
 # -------------------- END -------------------- #

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
       "dependencies": {
         "@manypkg/find-root": "2.2.3",
         "cosmiconfig": "9.0.0",
+        "dedent": "1.5.3",
         "meow": "13.2.0",
         "zod": "3.24.2",
         "zod-validation-error": "3.4.0",
@@ -422,6 +423,8 @@
     "de-indent": ["de-indent@1.0.2", "", {}, "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+
+    "dedent": ["dedent@1.5.3", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -1,3 +1,8 @@
 import config from '@codeowners-flow/eslint';
 
-export default config;
+export default [
+  ...config,
+  {
+    ignores: ['src/__fixtures__/codeowners.config.mjs'],
+  },
+];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@manypkg/find-root": "2.2.3",
     "cosmiconfig": "9.0.0",
+    "dedent": "1.5.3",
     "meow": "13.2.0",
     "zod": "3.24.2",
     "zod-validation-error": "3.4.0"

--- a/packages/cli/src/__fixtures__/codeowners.config.mjs
+++ b/packages/cli/src/__fixtures__/codeowners.config.mjs
@@ -1,0 +1,13 @@
+export default {
+  outDir: '.github',
+  rules: [
+    {
+      patterns: ['*'],
+      owners: [
+        {
+          name: '@company-team',
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -18,6 +18,7 @@ export async function loadUserConfig(
   rootDir: string,
   configRelativePath?: string,
 ) {
+  console.log('configRelativePath', configRelativePath);
   try {
     const result = configRelativePath
       ? await explorer.load(path.resolve(rootDir, configRelativePath))

--- a/packages/cli/src/generate-codeowners.test.ts
+++ b/packages/cli/src/generate-codeowners.test.ts
@@ -7,9 +7,9 @@ vi.mock('./config/index.js', () => ({
 }));
 
 const mockWriteFileSync = vi.fn();
-vi.mock('node:fs', () => ({
+vi.mock('node:fs/promises', () => ({
   default: {
-    writeFileSync: (...args: any) => mockWriteFileSync(...args),
+    writeFile: (...args: any) => mockWriteFileSync(...args),
   },
 }));
 
@@ -57,8 +57,7 @@ describe('fn: generateCodeOwners', () => {
       # -------------------- START -------------------- #
       ## Matching patterns...
       packages/core/**/* @team/core
-      # -------------------- END -------------------- #
-      "
+      # -------------------- END -------------------- #"
     `);
   });
 
@@ -73,8 +72,7 @@ describe('fn: generateCodeOwners', () => {
       # -------------------- START -------------------- #
       ## Matching patterns...
       packages/core/**/* @team/core
-      # -------------------- END -------------------- #
-      ",
+      # -------------------- END -------------------- #",
         "ownersPath": "/root/test/CODEOWNERS",
       }
     `);

--- a/packages/cli/src/get-codeowners-content.test.ts
+++ b/packages/cli/src/get-codeowners-content.test.ts
@@ -24,8 +24,7 @@ describe('getCodeOwnersContent', () => {
       # -------------------- START -------------------- #
       ## Matching patterns...
       packages/core/**/* @team/core
-      # -------------------- END -------------------- #
-      "
+      # -------------------- END -------------------- #"
     `);
   });
 
@@ -57,8 +56,7 @@ describe('getCodeOwnersContent', () => {
       packages/core @team/core
       pnpm-workspace.yaml @team/core
       .github/workflows @team/core
-      # -------------------- END -------------------- #
-      "
+      # -------------------- END -------------------- #"
     `);
   });
 
@@ -87,8 +85,7 @@ describe('getCodeOwnersContent', () => {
       # This is another comment
       ## Matching patterns...
       packages/core/**/* @team/core
-      # -------------------- END -------------------- #
-      "
+      # -------------------- END -------------------- #"
     `);
   });
 
@@ -117,8 +114,7 @@ describe('getCodeOwnersContent', () => {
       packages/core/**/* @team/core
       ## Except...
       packages/core/**/test
-      # -------------------- END -------------------- #
-      "
+      # -------------------- END -------------------- #"
     `);
   });
 
@@ -148,8 +144,7 @@ describe('getCodeOwnersContent', () => {
       ## Except...
       packages/core/**/test
       packages/core/**/mock
-      # -------------------- END -------------------- #
-      "
+      # -------------------- END -------------------- #"
     `);
   });
 });

--- a/packages/cli/src/get-codeowners-content.ts
+++ b/packages/cli/src/get-codeowners-content.ts
@@ -1,3 +1,5 @@
+import dedent from 'dedent';
+
 import type { UserConfig } from './config/index.js';
 
 export function getCodeOwnersContent(userConfig: UserConfig) {
@@ -34,7 +36,7 @@ export function getCodeOwnersContent(userConfig: UserConfig) {
     content.push(...partialConfig);
   }
 
-  return content.join('\n');
+  return dedent(content.join('\n'));
 }
 
 function getSectionDivider(heading: string): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,12 +2,14 @@ import meow from 'meow';
 
 import { generateCodeOwners } from './generate-codeowners.js';
 import { initProject } from './init.js';
+import { validateCodeowners } from './validate-codeowners.ts';
 
 const cli = meow(
   `
   Usage
   $ codeowners-flow generate
   $ codeowners-flow generate --config /path/to/config.mjs
+  $ codeowners-flow validate
   $ codeowners-flow init
 
   Example
@@ -30,6 +32,10 @@ const cli = meow(
 const [command] = cli.input;
 
 switch (command) {
+  case 'validate': {
+    validateCodeowners(cli.flags).then(console.log).catch(console.error);
+    break;
+  }
   case 'generate': {
     generateCodeOwners(cli.flags)
       .then(({ ownersPath }) => {

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -29,20 +29,21 @@ describe('fn: initProject', () => {
 
     expect(path).toMatchInlineSnapshot('"/path/to/codeowners.config.mjs"');
     expect(content).toMatchInlineSnapshot(`
-      "/** @type {import('@codeowners-flow/cli/config').UserConfig} */
-      export default {
-        outDir: '.github',
-        rules: [
-          {
-            patterns: ['*'],
-            owners: [
-              {
-                name: '@company-team',
-              },
-            ],
-          },
-        ],
-      };"
+      "import { defineConfig } from '@codeowners-flow/cli/config';
+
+        export default defineConfig({
+          outDir: '.github',
+          rules: [
+            {
+              patterns: ['*'],
+              owners: [
+                {
+                  name: '@company-team',
+                },
+              ],
+            },
+          ],
+        });"
     `);
   });
 });

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -16,18 +16,19 @@ export async function initProject() {
 }
 
 function getConfigTemplate() {
-  return `/** @type {import('@codeowners-flow/cli/config').UserConfig} */
-export default {
-  outDir: '.github',
-  rules: [
-    {
-      patterns: ['*'],
-      owners: [
-        {
-          name: '@company-team',
-        },
-      ],
-    },
-  ],
-};`;
+  return `import { defineConfig } from '@codeowners-flow/cli/config';
+
+  export default defineConfig({
+    outDir: '.github',
+    rules: [
+      {
+        patterns: ['*'],
+        owners: [
+          {
+            name: '@company-team',
+          },
+        ],
+      },
+    ],
+  });`;
 }

--- a/packages/cli/src/validate-codeowners.test.ts
+++ b/packages/cli/src/validate-codeowners.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { validateCodeowners } from './validate-codeowners.ts';
+
+const mockReadFile = vi.fn();
+vi.mock('node:fs/promises', async () => {
+  const actualModule = await vi.importActual('node:fs/promises');
+
+  return {
+    default: {
+      // @ts-expect-error - default is there
+      ...actualModule.default,
+      readFile: (...args: any[]) => mockReadFile(...args),
+    },
+  };
+});
+
+describe('fn: validateCodeowners', () => {
+  it('should exit process with status code 1', async () => {
+    const mockFile = `# This file was generated automatically by codeowners-flow. Do not edit it manually.
+    # Instead, modify the \`codeowners.config.mjs\` file located at the root of your project.
+
+    # -------------------- START -------------------- #
+    ## Matching patterns...
+    app/package.json @company-team
+    # -------------------- END -------------------- #
+    `;
+    mockReadFile.mockResolvedValue(mockFile);
+    const exitSpy = vi.spyOn(process, 'exit');
+    const consoleSpy = vi.spyOn(console, 'error');
+
+    await validateCodeowners({
+      config: 'packages/cli/src/__fixtures__/codeowners.config.mjs',
+    });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'CODEOWNERS file is not up to date or it was modified manually. Run `codeowners-flow generate` to update it.',
+    );
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it('should exit process with status code 0 if CODEOWNERS file is up to date', async () => {
+    const mockFile = `# This file was generated automatically by codeowners-flow. Do not edit it manually.
+    # Instead, modify the \`codeowners.config.mjs\` file located at the root of your project.
+
+    # -------------------- START -------------------- #
+    ## Matching patterns...
+    * @company-team
+    # -------------------- END -------------------- #`;
+
+    mockReadFile.mockResolvedValue(mockFile);
+    const exitSpy = vi.spyOn(process, 'exit');
+    const consoleSpy = vi.spyOn(console, 'log');
+
+    await validateCodeowners({
+      config: 'packages/cli/src/__fixtures__/codeowners.config.mjs',
+    });
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(consoleSpy).toHaveBeenCalledWith('CODEOWNERS file is up to date.');
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/cli/src/validate-codeowners.ts
+++ b/packages/cli/src/validate-codeowners.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs/promises';
+
+import dedent from 'dedent';
+
+import { getCodeOwners } from './generate-codeowners.ts';
+
+interface ValidateCodeOwnersOptions {
+  config?: string;
+}
+
+export async function validateCodeowners({
+  config,
+}: ValidateCodeOwnersOptions = {}) {
+  const { ownersPath, ownersContent } = await getCodeOwners(config);
+  console.log(ownersContent);
+  try {
+    const file = await fs.readFile(ownersPath);
+    const content = file.toString();
+
+    const isSame = dedent(content) === ownersContent.trim();
+
+    if (isSame === false) {
+      console.error(
+        'CODEOWNERS file is not up to date or it was modified manually. Run `codeowners-flow generate` to update it.',
+      );
+      process.exit(1);
+    } else {
+      console.log('CODEOWNERS file is up to date.');
+      process.exit(0);
+    }
+  } catch (error) {
+    console.error('Error reading codeowners file:', error);
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["vitest/globals"]
   },
-  "include": ["src/**/*", "vite.config.ts"]
+  "include": ["src/**/*", "vite.config.ts", "eslint.config.js"]
 }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `@codeowners-flow/cli` package, including a new command, improved string formatting, and refactoring for better code organization and readability. The most important changes are grouped by theme below.

### New Features:
* Added a new "validate" command to validate the `CODEOWNERS` file against a set of rules (`.changeset/light-keys-crash.md`, `packages/cli/src/index.ts`, `packages/cli/src/validate-codeowners.ts`, `packages/cli/src/validate-codeowners.test.ts`). [[1]](diffhunk://#diff-48fbb107d7556be3549cdf3d23d99c75b187f2f2e658abe2db8058136f351eb9R1-R7) [[2]](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR5-R12) [[3]](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR35-R38) [[4]](diffhunk://#diff-bd2d33e7e3742cb80f930adb97277303a0feeaeeb0eca1de190a9ea404f8575cR1-R34) [[5]](diffhunk://#diff-6e16408e0d8c0551a232191eb8b8ff568c193b7ce79b85943310365de0ec723eR1-R66)

### Enhancements:
* Enhanced string formatting while generating `CODEOWNERS` (`.changeset/chilly-clowns-start.md`).
* Fixed init boilerplate to import `defineConfig` from CLI (`.changeset/purple-candies-matter.md`, `packages/cli/src/init.ts`, `packages/cli/src/init.test.ts`). [[1]](diffhunk://#diff-d123ba77096d1b312c209ad526491aab42656da4ca73f93ccb29f916753d5678R1-R5) [[2]](diffhunk://#diff-721e663392566cacc136d592ed499c00fcf38dd0eb57c799d6c50d95131be846L19-R21) [[3]](diffhunk://#diff-721e663392566cacc136d592ed499c00fcf38dd0eb57c799d6c50d95131be846L32-R33) [[4]](diffhunk://#diff-426b589de47ae97f8c26118a729fbd8535c87f61c289218916bb5a3c34b67179L32-R34) [[5]](diffhunk://#diff-426b589de47ae97f8c26118a729fbd8535c87f61c289218916bb5a3c34b67179L45-R46)

### Refactoring:
* Refactored `generateCodeOwners` function to separate concerns and improve readability (`packages/cli/src/generate-codeowners.ts`).
* Updated `getCodeOwnersContent` to use `dedent` for better formatting (`packages/cli/src/get-codeowners-content.ts`). [[1]](diffhunk://#diff-43b266d25b6af4ac46c4e85d332425b84b5800e4b5ff444b1531918d0d5caea8R1-R2) [[2]](diffhunk://#diff-43b266d25b6af4ac46c4e85d332425b84b5800e4b5ff444b1531918d0d5caea8L37-R39)

### Dependency Updates:
* Added `dedent` dependency to `package.json` (`packages/cli/package.json`).

### Codeowners Configuration:
* Simplified `CODEOWNERS` file by consolidating team assignments (`.github/CODEOWNERS`, `packages/cli/src/__fixtures__/codeowners.config.mjs`). [[1]](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L5-R6) [[2]](diffhunk://#diff-6433ba9696ae8987a20240dfa98189cc19c31c6dee6d0efc58413d64110b0732R1-R13)